### PR TITLE
Copy relevant files from b2share/dockerize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+version: '2'
+services:
+    postgres:
+        image: postgres:9.6.2
+        environment:
+            - "POSTGRES_PASSWORD=${B2SHARE_POSTGRESQL_PASSWORD}"
+            - "POSTGRES_USER=${B2SHARE_POSTGRESQL_USER}"
+            - "PGDATA=/var/lib/postgresql/data"
+        volumes:
+            - "${B2SHARE_DATADIR}/postgres-data:/var/lib/postgresql/data"
+        expose:
+            - "5432"
+
+    b2share:
+        image: eudatb2share/b2share:2.0.1
+        environment:
+            - "B2ACCESS_CONSUMER_KEY=${B2ACCESS_CONSUMER_KEY}"
+            - "B2ACCESS_SECRET_KEY=${B2ACCESS_SECRET_KEY}"
+            - "USE_STAGING_B2ACCESS=${USE_STAGING_B2ACCESS}"
+            - "B2SHARE_SECRET_KEY=${B2SHARE_SECRET_KEY}"
+            - "B2SHARE_JSONSCHEMAS_HOST=${B2SHARE_JSONSCHEMAS_HOST}"
+            - "INIT_DB_AND_INDEX=${INIT_DB_AND_INDEX}"
+            - "LOAD_DEMO_COMMUNITIES_AND_RECORDS=${LOAD_DEMO_COMMUNITIES_AND_RECORDS}"
+            - "B2SHARE_PREFERRED_URL_SCHEME=https"
+            - "B2SHARE_SQLALCHEMY_DATABASE_URI='postgresql+psycopg2://${B2SHARE_POSTGRESQL_USER}:${B2SHARE_POSTGRESQL_PASSWORD}@postgres:5432/${B2SHARE_POSTGRESQL_DBNAME}'"
+            - "B2SHARE_CACHE_REDIS_HOST='redis'"
+            - "B2SHARE_CACHE_REDIS_URL='redis://redis:6379/0'"
+            - "B2SHARE_ACCOUNTS_SESSION_REDIS_URL='redis://redis:6379/1'"
+            - "B2SHARE_BROKER_URL='amqp://${B2SHARE_RABBITMQ_USER}:${B2SHARE_RABBITMQ_PASS}@mq:5672/'"
+            - "B2SHARE_CELERY_RESULT_BACKEND='redis://redis:6379/2'"
+            - "B2SHARE_SEARCH_ELASTIC_HOSTS='elasticsearch'"
+        volumes:
+            - "${B2SHARE_DATADIR}/b2share-data:/usr/var/b2share-instance"
+        expose:
+            - "5000"
+        links:
+            - elasticsearch
+            - redis
+            - postgres
+
+    elasticsearch:
+        build: elasticsearch
+        expose:
+            - "9200"
+            - "9300"
+        volumes:
+            - "${B2SHARE_DATADIR}/elasticsearch-data:/usr/share/elasticsearch/data"
+
+    redis:
+        image: redis:3.2-alpine
+        expose:
+            - "6379"
+        volumes:
+            - "${B2SHARE_DATADIR}/redis-data:/data"
+
+    nginx:
+        build: nginx
+        ports:
+            - "80:80"
+            - "443:443"
+        # volumes:
+        #     - "${B2SHARE_DATADIR}/nginx-data/ssl:/etc/ssl/"
+        links:
+            - b2share
+
+    mq:
+        hostname: b2share-redis
+        image: rabbitmq:3.6-management-alpine
+        restart: "always"
+        environment:
+            - "RABBITMQ_DEFAULT_USER=${B2SHARE_RABBITMQ_USER}"
+            - "RABBITMQ_DEFAULT_PASS=${B2SHARE_RABBITMQ_PASS}"
+        expose:
+            - "15672"
+            - "5672"
+        volumes:
+            - "${B2SHARE_DATADIR}/rabbitmq-data:/var/lib/rabbitmq"

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,7 @@
+FROM elasticsearch:2.2
+EXPOSE 9200 9300
+
+RUN cd /usr/share/elasticsearch && \
+    yes | ./bin/plugin install mapper-attachments
+
+CMD ["elasticsearch"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.11
+EXPOSE 80 443
+
+RUN rm /etc/nginx/conf.d/*.conf
+RUN mkdir -p /etc/ssl/
+RUN openssl genrsa -out /etc/ssl/b2share.key 2048
+RUN openssl req -new -key /etc/ssl/b2share.key -out /etc/ssl/b2share.csr -subj "/C=CH/ST=Geneva/L=Geneva/O=B2Share Test Certificate/OU=B2Share/CN=example.com"
+RUN openssl req -x509 -days 365 -key /etc/ssl/b2share.key -in /etc/ssl/b2share.csr -out /etc/ssl/b2share.crt
+COPY b2share.conf /etc/nginx/conf.d/
+
+CMD ["nginx","-g","daemon off;"]

--- a/nginx/b2share.conf
+++ b/nginx/b2share.conf
@@ -1,0 +1,51 @@
+server {
+        listen 80;
+        charset utf-8;
+
+        location /oai2d {
+                proxy_pass http://b2share:5000/api/oai2d;
+                proxy_set_header Host $host;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location / {
+                return 301 https://$http_host$request_uri;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+                root /usr/share/nginx/html;
+        }
+}
+
+server {
+        listen 443 ssl;
+        charset utf-8;
+        ssl_certificate         /etc/ssl/b2share.crt;
+        ssl_certificate_key     /etc/ssl/b2share.key;
+        ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers             HIGH:!aNULL:!MD5;
+
+        client_body_timeout 600s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        location /api/files {
+                proxy_pass http://b2share:5000;
+                proxy_request_buffering off;
+                client_max_body_size 1000g;
+        }
+
+        location / {
+                proxy_pass http://b2share:5000;
+                client_max_body_size 100m;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+                root /usr/share/nginx/html;
+        }
+}


### PR DESCRIPTION
Use prebuilt b2share image in docker-compose

The purpose of this `dockerize` repository is to simplify the user installation procedure for the b2share demo.