### PR TITLE
vtatti: replace piped yes with automatic confirmation option

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -2,6 +2,6 @@ FROM elasticsearch:2.2
 EXPOSE 9200 9300
 
 RUN cd /usr/share/elasticsearch && \
-    yes | ./bin/plugin install mapper-attachments
+    ./bin/plugin install -b mapper-attachments
 
 CMD ["elasticsearch"]


### PR DESCRIPTION
When installing elasticsearch plugin, replace piped 'yes' utility with automatic confirmation option