### PR TITLE
Disable use of custom b2access domain certificate

### DIFF
--- a/b2share.sh
+++ b/b2share.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+# This file is supposed to live in a docker container
+
+# wait for all the services to start
+# FIXME: we should have some shell code to check that instead of a sleep.
+sleep 30
+
+if [ ! -f /usr/var/b2share-instance/provisioned ]; then
+
+    # if a config file already exists, continue
+    /usr/bin/b2share demo load_config || true
+
+    if [ "${INIT_DB_AND_INDEX}" = "1" ]; then
+        /usr/bin/b2share db init
+        /usr/bin/b2share upgrade run -v
+        sleep 20
+    fi
+
+    if [ "${LOAD_DEMO_COMMUNITIES_AND_RECORDS}" = "1" ]; then
+        /usr/bin/b2share demo load_data
+    elif [ "${INIT_DB_AND_INDEX}" = "1" ]; then
+        # add default location
+        /usr/bin/b2share files add-location 'local' file:///usr/var/b2share-instance/files --default
+    fi
+
+    touch /usr/var/b2share-instance/provisioned
+fi
+
+#if [ "${USE_STAGING_B2ACCESS}" = "1" ]; then
+#    export SSL_CERT_FILE="/eudat/b2share/staging_b2access.pem"
+#fi
+
+# safe to run even when up to date
+/usr/bin/b2share upgrade run -v
+
+/usr/bin/supervisord

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
             - "B2SHARE_SEARCH_ELASTIC_HOSTS='elasticsearch'"
         volumes:
             - "${B2SHARE_DATADIR}/b2share-data:/usr/var/b2share-instance"
+            - "${PWD}/b2share.sh:/eudat/b2share.sh"
         expose:
             - "5000"
         links:


### PR DESCRIPTION
- A self-supplied, although not self-signed, domain certificate for B2ACCESS
  staging instance is included with B2SHARE.
- This certificate expired in 07/2019.
- This commit disables the use of this self-supplied domain certificate,
  since current B2ACCESS staging domain certificate is trusted properly
  by urllib2.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@csc.fi>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eudat-b2share/dockerize/10)
<!-- Reviewable:end -->
