### PR TITLE
Add container for creating regular DB dumps

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+
+RUN apk add postgresql-client
+RUN apk add dcron
+
+COPY pgsqlbackup.sh /usr/local/bin/pgsqlbackup.sh
+
+ENV DB_NAME="b2share"
+ENV DB_HOST="postgres"
+ENV DB_PORT="5432"
+
+# Create cron job
+COPY crontab /etc/cron.d/pgsqlbackup-cron
+RUN chmod 0644 /etc/cron.d/pgsqlbackup-cron
+
+RUN touch /test.txt
+
+CMD crond -s /etc/cron.d -b && tail -f /test.txt
+

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,0 +1,1 @@
+0 1 * * * /bin/sh /usr/local/bin/pgsqlbackup.sh 2>&1

--- a/backup/pgsqlbackup.sh
+++ b/backup/pgsqlbackup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# PostgreSQL Backup Script
+#  Dumps postgresql databases to a file for another backup tool to pick up.
+#
+
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+IFS=' '
+
+##### START CONFIG ###################################################
+
+DBHOST=$DB_HOST
+DBPORT=$DB_PORT
+DBNAME=$DB_NAME
+DBUSER=$POSTGRES_USER
+
+DIR=/usr/local/share/pgsql_dumps
+
+# Ensure backup directory exist.
+if [ ! -d "${DIR}" ]; then
+    /bin/mkdir -p ${DIR}
+fi
+
+PREFIX=pgsql_backup_
+
+##### STOP CONFIG ####################################################
+FILE="${DIR}/${PREFIX}${DBNAME}_`date +%Y%m%d-%H%M%S`.sql"
+COMMAND="/usr/bin/pg_dump --file=${FILE} --blobs --dbname=${DBNAME} --host=${DBHOST} --port=${DBPORT} --username=${DBUSER}"
+/bin/echo ${COMMAND} >> /test.txt
+/usr/bin/pg_dump --file=${FILE} --blobs --dbname=${DBNAME} --host=${DBHOST} --port=${DBPORT} --username=${DBUSER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,3 +75,12 @@ services:
             - "5672"
         volumes:
             - "${B2SHARE_DATADIR}/rabbitmq-data:/var/lib/rabbitmq"
+
+    backup:
+        build: backup
+        environment:
+            - "PGPASSWORD=${B2SHARE_POSTGRESQL_PASSWORD}"
+            - "POSTGRES_USER=${B2SHARE_POSTGRESQL_USER}"
+        volumes:
+            - "${B2SHARE_DATADIR}/db_dump:/usr/local/share/pgsql_dumps"
+


### PR DESCRIPTION
The container creates every day at 1 a.m. UTC a database dump and stores it into a specific folder within the persistency path.