### PR TITLE
Add record view aggregation mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
             - "${B2SHARE_DATADIR}/b2share-data:/usr/var/b2share-instance"
             - "./elasticsearch/mappings/record-view:/usr/local/lib/python3.6/site-packages/invenio_stats/contrib/record_view/v2"
             - "./elasticsearch/mappings/file-download:/usr/local/lib/python3.6/site-packages/invenio_stats/contrib/file_download/v2"
+            - "./elasticsearch/mappings/record-view-agg:/usr/local/lib/python3.6/site-packages/invenio_stats/contrib/aggregations/aggr_record_view/v2"
 
     b2share:
         extends: b2share-base
@@ -121,4 +122,3 @@ services:
     #         - "POSTGRES_USER=${B2SHARE_POSTGRESQL_USER}"
     #     volumes:
     #         - "${B2SHARE_DATADIR}/db_dump:/usr/local/share/pgsql_dumps"
-

--- a/elasticsearch/mappings/record-view-agg/aggr-record-view-v1.json
+++ b/elasticsearch/mappings/record-view-agg/aggr-record-view-v1.json
@@ -1,0 +1,54 @@
+{
+    "template": "stats-record-view-*",
+    "settings": {
+      "index": {
+        "refresh_interval": "1m"
+      }
+    },
+    "mappings": {
+      "record-view-aggregation": {
+        "_source": {
+          "enabled": true
+        },
+        "_all": {
+          "enabled": false
+        },
+        "date_detection": false,
+        "numeric_detection": false,
+        "properties": {
+          "timestamp": {
+            "type": "date",
+            "format": "date_optional_time"
+          },
+          "count": {
+            "type": "integer",
+            "index": "not_analyzed"
+          },
+          "record_id": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "collection": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "community": {
+            "type": "string",
+            "index": "not_analyzed"
+          }
+        }
+      },
+      "record-view-bookmark": {
+        "date_detection": false,
+        "properties": {
+          "date": {
+            "type": "date",
+            "format": "date_optional_time"
+          }
+        }
+      }
+    },
+    "aliases": {
+      "stats-record-view": {}
+    }
+  }


### PR DESCRIPTION
Add missing elasticsearch mapping for record view aggregations. To update the mapping, run b2share index init --force, remove old stats-record-view indices. Re-aggregation is automatic.